### PR TITLE
Implement (almost) all `Result` classes

### DIFF
--- a/src/main/java/edu/utdallas/davisbase/result/CreateIndexResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/CreateIndexResult.java
@@ -1,5 +1,64 @@
 package edu.utdallas.davisbase.result;
 
+import static java.util.Objects.hash;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class CreateIndexResult implements Result {
-  // TODO Implement CreateIndexResult
+
+  private final String tableName;
+  private final String columnName;
+
+  /**
+   * @param tableName the name of the table on which the index was created (not null)
+   * @param columnName the name of the column on which the index was created (not null)
+   */
+  public CreateIndexResult(String tableName, String columnName) {
+    checkNotNull(tableName);
+    checkNotNull(columnName);
+
+    this.tableName = tableName;
+    this.columnName = columnName;
+  }
+
+  /**
+   * @return the name of the table on which the index was created (not null)
+   */
+  public String getTableName() {
+    return tableName;
+  }
+
+  /**
+   * @return the name of the column on which the index was created (not null)
+   */
+  public String getColumnName() {
+    return columnName;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof CreateIndexResult)) {
+      return false;
+    }
+
+    CreateIndexResult other = (CreateIndexResult) obj;
+    return
+        getTableName().equals(other.getTableName()) &&
+        getColumnName().equals(other.getColumnName());
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getTableName(), getColumnName());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(CreateIndexResult.class)
+        .add("tableName", getTableName())
+        .add("columnName", getColumnName())
+        .toString();
+  }
+
 }

--- a/src/main/java/edu/utdallas/davisbase/result/CreateIndexResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/CreateIndexResult.java
@@ -1,4 +1,5 @@
 package edu.utdallas.davisbase.result;
 
 public class CreateIndexResult implements Result {
+  // TODO Implement CreateIndexResult
 }

--- a/src/main/java/edu/utdallas/davisbase/result/CreateTableResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/CreateTableResult.java
@@ -36,7 +36,7 @@ public class CreateTableResult implements Result {
 
   @Override
   public int hashCode() {
-    return hash(tableName);
+    return hash(getTableName());
   }
 
   @Override

--- a/src/main/java/edu/utdallas/davisbase/result/CreateTableResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/CreateTableResult.java
@@ -1,5 +1,49 @@
 package edu.utdallas.davisbase.result;
 
+import static java.util.Objects.hash;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class CreateTableResult implements Result {
-  // TODO Implement CreateTableResult
+
+  private final String tableName;
+
+  /**
+   * @param tableName the name of the table that was created (not null)
+   */
+  public CreateTableResult(String tableName) {
+    checkNotNull(tableName);
+
+    this.tableName = tableName;
+  }
+
+  /**
+   * @return the name of the table that was created (not null)
+   */
+  public String getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof CreateTableResult)) {
+      return false;
+    }
+
+    CreateTableResult other = (CreateTableResult) obj;
+    return getTableName().equals(other.getTableName());
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(tableName);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(CreateTableResult.class)
+        .add("tableName", getTableName())
+        .toString();
+  }
+
 }

--- a/src/main/java/edu/utdallas/davisbase/result/CreateTableResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/CreateTableResult.java
@@ -1,4 +1,5 @@
 package edu.utdallas.davisbase.result;
 
 public class CreateTableResult implements Result {
+  // TODO Implement CreateTableResult
 }

--- a/src/main/java/edu/utdallas/davisbase/result/DeleteResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/DeleteResult.java
@@ -1,5 +1,65 @@
 package edu.utdallas.davisbase.result;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+import static java.util.Objects.hash;
+
 public class DeleteResult implements Result {
-  // TODO Implement DeleteResult
+
+  private final String tableName;
+  private final int rowsDeleted;
+
+  /**
+   * @param tableName   the name of the table from which rows were deleted (not null)
+   * @param rowsDeleted the count of rows that were deleted (not negative)
+   */
+  public DeleteResult(String tableName, int rowsDeleted) {
+    checkNotNull(tableName);
+    checkArgument(0 <= rowsDeleted, format("rowsDeleted must be nonnegative, but is %d", rowsDeleted));
+
+    this.tableName = tableName;
+    this.rowsDeleted = rowsDeleted;
+  }
+
+  /**
+   * @return the name of the table from which rows were deleted (not null)
+   */
+  public String getTableName() {
+    return tableName;
+  }
+
+  /**
+   * @return the count of rows deleted (not negative)
+   */
+  public int getRowsDeleted() {
+    return rowsDeleted;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof DeleteResult)) {
+      return false;
+    }
+
+    DeleteResult other = (DeleteResult) obj;
+    return
+      getTableName().equals(other.getTableName()) &&
+      getRowsDeleted() == other.getRowsDeleted();
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getTableName(), getRowsDeleted());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(DeleteResult.class)
+        .add("tableName", getTableName())
+        .add("rowsDeleted", getRowsDeleted())
+        .toString();
+  }
+
 }

--- a/src/main/java/edu/utdallas/davisbase/result/DeleteResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/DeleteResult.java
@@ -17,7 +17,9 @@ public class DeleteResult implements Result {
    */
   public DeleteResult(String tableName, int rowsDeleted) {
     checkNotNull(tableName);
-    checkArgument(0 <= rowsDeleted, format("rowsDeleted must be nonnegative, but is %d", rowsDeleted));
+    checkArgument(0 <= rowsDeleted,
+        format("rowsDeleted must be nonnegative, but is %d",
+            rowsDeleted));
 
     this.tableName = tableName;
     this.rowsDeleted = rowsDeleted;

--- a/src/main/java/edu/utdallas/davisbase/result/DeleteResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/DeleteResult.java
@@ -1,4 +1,5 @@
 package edu.utdallas.davisbase.result;
 
 public class DeleteResult implements Result {
+  // TODO Implement DeleteResult
 }

--- a/src/main/java/edu/utdallas/davisbase/result/DropTableResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/DropTableResult.java
@@ -9,7 +9,7 @@ public class DropTableResult implements Result {
   private final String tableName;
 
   /**
-   * @param tableName the name of the table that was dropped
+   * @param tableName the name of the table that was dropped (not null)
    */
   public DropTableResult(String tableName) {
     checkNotNull(tableName);
@@ -18,7 +18,7 @@ public class DropTableResult implements Result {
   }
 
   /**
-   * @return the name of the table that was dropped
+   * @return the name of the table that was dropped (not null)
    */
   public String getTableName() {
     return tableName;

--- a/src/main/java/edu/utdallas/davisbase/result/DropTableResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/DropTableResult.java
@@ -1,4 +1,5 @@
 package edu.utdallas.davisbase.result;
 
 public class DropTableResult implements Result {
+  // TODO Implement DropTableResult
 }

--- a/src/main/java/edu/utdallas/davisbase/result/DropTableResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/DropTableResult.java
@@ -1,5 +1,49 @@
 package edu.utdallas.davisbase.result;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.hash;
+
 public class DropTableResult implements Result {
-  // TODO Implement DropTableResult
+
+  private final String tableName;
+
+  /**
+   * @param tableName the name of the table that was dropped
+   */
+  public DropTableResult(String tableName) {
+    checkNotNull(tableName);
+
+    this.tableName = tableName;
+  }
+
+  /**
+   * @return the name of the table that was dropped
+   */
+  public String getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof DropTableResult)) {
+      return false;
+    }
+
+    DropTableResult other = (DropTableResult) obj;
+    return getTableName().equals(other.getTableName());
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getTableName());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(DropTableResult.class)
+        .add("tableName", getTableName())
+        .toString();
+  }
+
 }

--- a/src/main/java/edu/utdallas/davisbase/result/ExitResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/ExitResult.java
@@ -1,4 +1,5 @@
 package edu.utdallas.davisbase.result;
 
 public class ExitResult implements Result {
+  // TODO Implement ExitResult
 }

--- a/src/main/java/edu/utdallas/davisbase/result/ExitResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/ExitResult.java
@@ -1,5 +1,4 @@
 package edu.utdallas.davisbase.result;
 
 public class ExitResult implements Result {
-  // TODO Implement ExitResult
 }

--- a/src/main/java/edu/utdallas/davisbase/result/ExitResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/ExitResult.java
@@ -1,4 +1,24 @@
 package edu.utdallas.davisbase.result;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+import java.util.Objects;
+
 public class ExitResult implements Result {
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj != null && obj instanceof ExitResult;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getClass());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(getClass()).toString();
+  }
+
 }

--- a/src/main/java/edu/utdallas/davisbase/result/ExitResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/ExitResult.java
@@ -13,12 +13,12 @@ public class ExitResult implements Result {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getClass());
+    return Objects.hashCode(ExitResult.class);
   }
 
   @Override
   public String toString() {
-    return toStringHelper(getClass()).toString();
+    return toStringHelper(ExitResult.class).toString();
   }
 
 }

--- a/src/main/java/edu/utdallas/davisbase/result/InsertResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/InsertResult.java
@@ -1,4 +1,5 @@
 package edu.utdallas.davisbase.result;
 
 public class InsertResult implements Result {
+  // TODO Implement InsertResult
 }

--- a/src/main/java/edu/utdallas/davisbase/result/InsertResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/InsertResult.java
@@ -1,5 +1,67 @@
 package edu.utdallas.davisbase.result;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+import static java.util.Objects.hash;
+
 public class InsertResult implements Result {
-  // TODO Implement InsertResult
+
+  private final String tableName;
+  private final int rowsInserted;
+
+  /**
+   * @param tableName    the name of the table into which rows were inserted (not null)
+   * @param rowsInserted the count of rows that were inserted (not negative)
+   */
+  public InsertResult(String tableName, int rowsInserted) {
+    checkNotNull(tableName);
+    checkArgument(0 <= rowsInserted,
+        format("rowsInserted must be nonnegative, but is %d",
+            rowsInserted));
+
+    this.tableName = tableName;
+    this.rowsInserted = rowsInserted;
+  }
+
+  /**
+   * @return the name of the table into which rows were inserted (not null)
+   */
+  public String getTableName() {
+    return tableName;
+  }
+
+  /**
+   * @return the count of rows that were inserted (not negative)
+   */
+  public int getRowsInserted() {
+    return rowsInserted;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof InsertResult)) {
+      return false;
+    }
+
+    InsertResult other = (InsertResult) obj;
+    return
+        getTableName().equals(other.getTableName()) &&
+        getRowsInserted() == other.getRowsInserted();
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getTableName(), getRowsInserted());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(InsertResult.class)
+        .add("tableName", getTableName())
+        .add("rowsInserted", getRowsInserted())
+        .toString();
+  }
+
 }

--- a/src/main/java/edu/utdallas/davisbase/result/Result.java
+++ b/src/main/java/edu/utdallas/davisbase/result/Result.java
@@ -1,5 +1,4 @@
 package edu.utdallas.davisbase.result;
 
 public interface Result {
-  // TODO Implement Result
 }

--- a/src/main/java/edu/utdallas/davisbase/result/Result.java
+++ b/src/main/java/edu/utdallas/davisbase/result/Result.java
@@ -1,4 +1,5 @@
 package edu.utdallas.davisbase.result;
 
 public interface Result {
+  // TODO Implement Result
 }

--- a/src/main/java/edu/utdallas/davisbase/result/SelectResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/SelectResult.java
@@ -1,4 +1,5 @@
 package edu.utdallas.davisbase.result;
 
 public class SelectResult implements Result {
+  // TODO Implement SelectResult
 }

--- a/src/main/java/edu/utdallas/davisbase/result/ShowTablesResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/ShowTablesResult.java
@@ -2,11 +2,12 @@ package edu.utdallas.davisbase.result;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.hash;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 public class ShowTablesResult implements Result {
@@ -18,7 +19,8 @@ public class ShowTablesResult implements Result {
   private final List<String> tableNames;
 
   /**
-   * @param tableNames the non-null collection of non-null table names
+   * @param tableNames the collection of (nonnull) names of the tables currently defined in this
+   *                   DavisBase storage instance (not null)
    */
   public ShowTablesResult(Collection<String> tableNames) {
     checkNotNull(tableNames);
@@ -27,11 +29,12 @@ public class ShowTablesResult implements Result {
     }
 
     // Copy the collection and then wrap it in an unmodifiable view to ensure immutability.
-    this.tableNames = Collections.unmodifiableList(new ArrayList<>(tableNames));
+    this.tableNames = unmodifiableList(new ArrayList<>(tableNames));
   }
 
   /**
-   * @return the non-null unmodifiable list of non-null table names
+   * @return an unmodifiable list of the (nonnull) names of the tables defined in this DavisBase
+   *         storage instance at the time this {@link ShowTablesResult} was created (not null)
    */
   public List<String> getTableNames() {
     return tableNames;
@@ -44,18 +47,18 @@ public class ShowTablesResult implements Result {
     }
 
     ShowTablesResult other = (ShowTablesResult) obj;
-    return tableNames.equals(other.tableNames);
+    return getTableNames().equals(other.getTableNames());
   }
 
   @Override
   public int hashCode() {
-    return tableNames.hashCode();
+    return hash(getTableNames());
   }
 
   @Override
   public String toString() {
-    return toStringHelper(this)
-        .add("tableNames", Arrays.toString(tableNames.toArray()))
+    return toStringHelper(ShowTablesResult.class)
+        .add("tableNames", Arrays.toString(getTableNames().toArray()))
         .toString();
   }
 

--- a/src/main/java/edu/utdallas/davisbase/result/ShowTablesResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/ShowTablesResult.java
@@ -1,5 +1,62 @@
 package edu.utdallas.davisbase.result;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
 public class ShowTablesResult implements Result {
-  // TODO Implement ShowTablesResult
+
+  /**
+   * The non-null immutable list of non-null table names. Table names are not
+   * guaranteed to be sorted, unique, or consistently cased.
+   */
+  private final List<String> tableNames;
+
+  /**
+   * @param tableNames the non-null collection of non-null table names
+   */
+  public ShowTablesResult(Collection<String> tableNames) {
+    checkNotNull(tableNames);
+    for (String tableName : tableNames) {
+      checkNotNull(tableName);
+    }
+
+    // Copy the collection and then wrap it in an unmodifiable view to ensure immutability.
+    this.tableNames = Collections.unmodifiableList(new ArrayList<>(tableNames));
+  }
+
+  /**
+   * @return the non-null unmodifiable list of non-null table names
+   */
+  public List<String> getTableNames() {
+    return tableNames;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof ShowTablesResult)) {
+      return false;
+    }
+
+    ShowTablesResult other = (ShowTablesResult) obj;
+    return tableNames.equals(other.tableNames);
+  }
+
+  @Override
+  public int hashCode() {
+    return tableNames.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("tableNames", Arrays.toString(tableNames.toArray()))
+        .toString();
+  }
+
 }

--- a/src/main/java/edu/utdallas/davisbase/result/ShowTablesResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/ShowTablesResult.java
@@ -1,4 +1,5 @@
 package edu.utdallas.davisbase.result;
 
 public class ShowTablesResult implements Result {
+  // TODO Implement ShowTablesResult
 }

--- a/src/main/java/edu/utdallas/davisbase/result/UpdateResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/UpdateResult.java
@@ -1,4 +1,5 @@
 package edu.utdallas.davisbase.result;
 
 public class UpdateResult implements Result {
+  // TODO Implement UpdateResult
 }

--- a/src/main/java/edu/utdallas/davisbase/result/UpdateResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/UpdateResult.java
@@ -1,5 +1,67 @@
 package edu.utdallas.davisbase.result;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+import static java.util.Objects.hash;
+
 public class UpdateResult implements Result {
-  // TODO Implement UpdateResult
+
+  private final String tableName;
+  private final int rowsUpdated;
+
+  /**
+   * @param tableName   the name of the table that was updated (not null)
+   * @param rowsUpdated the count of rows updated (not negative)
+   */
+  public UpdateResult(String tableName, int rowsUpdated) {
+    checkNotNull(tableName);
+    checkArgument(0 <= rowsUpdated,
+        format("rowsUpdated must be nonnegative, but is %d",
+            rowsUpdated));
+
+    this.tableName = tableName;
+    this.rowsUpdated = rowsUpdated;
+  }
+
+  /**
+   * @return the name of the table that was updated (not null)
+   */
+  public String getTableName() {
+    return tableName;
+  }
+
+  /**
+   * @return the count of rows updated (not negative)
+   */
+  public int getRowsUpdated() {
+    return rowsUpdated;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof UpdateResult)) {
+      return false;
+    }
+
+    UpdateResult other = (UpdateResult) obj;
+    return
+        getTableName().equals(other.getTableName()) &&
+        getRowsUpdated() == other.getRowsUpdated();
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getTableName(), getRowsUpdated());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(UpdateResult.class)
+        .add("tableName", getTableName())
+        .add("rowsUpdated", getRowsUpdated())
+        .toString();
+  }
+
 }


### PR DESCRIPTION
Implement (almost) all subclasses of `edu.utdallas.davisbase.result.Result`:

- `CreateIndexResult`
- `CreateTableResult`
- `DeleteResult`
- `DropTableResult`
- `ExitResult`
- `InsertResult`
- `ShowTablesResult`
- `UpdateResult`

The only result type left to be implemented is `SelectResult`, which is the most complicated.

This pull request is intended to go ahead and review/confirm/merge-to-`master` those result types implemented so far in order to unblock @bhrao since the package `edu.utdallas.davisbase.host` is dependent on the package `edu.utdallas.davisbase.result`.

Requesting code review from @bhrao (who will be using the result types to implement the class `edu.utdallas.davisbase.host.Host`) and @hitharr (who may be using the result types depending on who all tackles the package `edu.utdallas.davisbase.compile`).