### PR TITLE
`catalog` Package

### DIFF
--- a/src/main/java/edu/utdallas/davisbase/catalog/CatalogTable.java
+++ b/src/main/java/edu/utdallas/davisbase/catalog/CatalogTable.java
@@ -1,0 +1,39 @@
+package edu.utdallas.davisbase.catalog;
+
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static java.util.Collections.unmodifiableList;
+import java.util.List;
+
+/**
+ * An enumerated type of {@code CatalogTable}.
+ */
+public enum CatalogTable {
+  DAVISBASE_TABLES  (DavisBaseTablesTableColumn.values()),
+  DAVISBASE_COLUMNS (DavisBaseColumnsTableColumn.values());
+
+  private final CatalogTableColumn[] columns;
+
+  private CatalogTable(CatalogTableColumn[] columns) {
+    assert columns != null : "columns should not be null";
+    assert stream(columns).allMatch(col -> col != null) : "Not all columns are nonnull";
+
+    this.columns = columns;
+  }
+
+  /**
+   * @return the canonical name of this table (not null)
+   */
+  public String getName() {
+    return name().toLowerCase();
+  }
+
+  /**
+   * @return an unmodifiable list of the (nonnull) {@link CatalogTableColumn}s that make up this
+   *         table's schema, ordered by {@link CatalogTableColumn#getOrdinalPosition()} (not null)
+   */
+  public List<CatalogTableColumn> getColumns() {
+    return unmodifiableList(asList(columns));
+  }
+
+}

--- a/src/main/java/edu/utdallas/davisbase/catalog/CatalogTableColumn.java
+++ b/src/main/java/edu/utdallas/davisbase/catalog/CatalogTableColumn.java
@@ -3,16 +3,30 @@ package edu.utdallas.davisbase.catalog;
 import edu.utdallas.davisbase.DataType;
 
 /**
- * A column schema for a catalog table.
+ * A column schema for a {@link CatalogTable}.
  */
 public interface CatalogTableColumn {
 
+  /**
+   * @return the canonical name of this column (not null)
+   */
   public String getName();
 
+  /**
+   * @return the {@link DataType} of this column (not null)
+   */
   public DataType getDataType();
 
+  /**
+   * @return the zero-based ordinal position of this column in the table to which it belongs (not
+   *         negative, less than {@link java.lang.Byte#MAX_VALUE Byte.MAX_VALUE}, and unique within
+   *         a table)
+   */
   public byte getOrdinalPosition();
 
+  /**
+   * @return {@code true} if-and-only-if this column accepts DavisBase {@code null} values
+   */
   public boolean isNullable();
 
 }

--- a/src/main/java/edu/utdallas/davisbase/catalog/CatalogTableColumn.java
+++ b/src/main/java/edu/utdallas/davisbase/catalog/CatalogTableColumn.java
@@ -7,8 +7,6 @@ import edu.utdallas.davisbase.DataType;
  */
 public interface CatalogTableColumn {
 
-  public CatalogTable getTable();
-
   public String getName();
 
   public DataType getDataType();

--- a/src/main/java/edu/utdallas/davisbase/catalog/CatalogTableColumn.java
+++ b/src/main/java/edu/utdallas/davisbase/catalog/CatalogTableColumn.java
@@ -1,0 +1,20 @@
+package edu.utdallas.davisbase.catalog;
+
+import edu.utdallas.davisbase.DataType;
+
+/**
+ * A column schema for a catalog table.
+ */
+public interface CatalogTableColumn {
+
+  public CatalogTable getTable();
+
+  public String getName();
+
+  public DataType getDataType();
+
+  public byte getOrdinalPosition();
+
+  public boolean isNullable();
+
+}

--- a/src/main/java/edu/utdallas/davisbase/catalog/DavisBaseColumnsTableColumn.java
+++ b/src/main/java/edu/utdallas/davisbase/catalog/DavisBaseColumnsTableColumn.java
@@ -21,7 +21,6 @@ public enum DavisBaseColumnsTableColumn implements CatalogTableColumn {
 
   private DavisBaseColumnsTableColumn(DataType dataType, boolean isNullable) {
     assert dataType != null : "dataType should not be null";
-    assert ordinal() < Byte.MAX_VALUE : format("ordinal() should be less than %d", Byte.MAX_VALUE);
 
     this.dataType = dataType;
     this.isNullable = isNullable;
@@ -39,6 +38,8 @@ public enum DavisBaseColumnsTableColumn implements CatalogTableColumn {
 
   @Override
   public byte getOrdinalPosition() {
+    assert ordinal() < Byte.MAX_VALUE : format("ordinal() should be less than %d", Byte.MAX_VALUE);
+
     return (byte) ordinal();
   }
 

--- a/src/main/java/edu/utdallas/davisbase/catalog/DavisBaseColumnsTableColumn.java
+++ b/src/main/java/edu/utdallas/davisbase/catalog/DavisBaseColumnsTableColumn.java
@@ -1,0 +1,50 @@
+package edu.utdallas.davisbase.catalog;
+
+import static java.lang.String.format;
+
+import edu.utdallas.davisbase.DataType;
+
+/**
+ * An enumerated column schema for the {@link CatalogTable#DAVISBASE_COLUMNS davisbase_columns}
+ * catalog table.
+ */
+public enum DavisBaseColumnsTableColumn implements CatalogTableColumn {
+  ROWID            (DataType.INT,     false),
+  TABLE_NAME       (DataType.TEXT,    false),
+  COLUMN_NAME      (DataType.TEXT,    false),
+  DATA_TYPE        (DataType.TEXT,    false),
+  ORDINAL_POSITION (DataType.TINYINT, false),
+  IS_NULLABLE      (DataType.TEXT,    false);
+
+  private final DataType dataType;
+  private final boolean isNullable;
+
+  private DavisBaseColumnsTableColumn(DataType dataType, boolean isNullable) {
+    assert dataType != null : "dataType should not be null";
+    assert ordinal() < Byte.MAX_VALUE : format("ordinal() should be less than %d", Byte.MAX_VALUE);
+
+    this.dataType = dataType;
+    this.isNullable = isNullable;
+  }
+
+  @Override
+  public String getName() {
+    return name().toLowerCase();
+  }
+
+  @Override
+  public DataType getDataType() {
+    return dataType;
+  }
+
+  @Override
+  public byte getOrdinalPosition() {
+    return (byte) ordinal();
+  }
+
+  @Override
+  public boolean isNullable() {
+    return isNullable;
+  }
+
+}

--- a/src/main/java/edu/utdallas/davisbase/catalog/DavisBaseTablesTableColumn.java
+++ b/src/main/java/edu/utdallas/davisbase/catalog/DavisBaseTablesTableColumn.java
@@ -1,0 +1,46 @@
+package edu.utdallas.davisbase.catalog;
+
+import static java.lang.String.format;
+
+import edu.utdallas.davisbase.DataType;
+
+/**
+ * An enumerated column schema for the {@link CatalogTable#DAVISBASE_TABLES davisbase_tables}
+ * catalog table.
+ */
+public enum DavisBaseTablesTableColumn implements CatalogTableColumn {
+  ROWID      (DataType.INT,  false),
+  TABLE_NAME (DataType.TEXT, false);
+
+  private final DataType dataType;
+  private final boolean isNullable;
+
+  private DavisBaseTablesTableColumn(DataType dataType, boolean isNullable) {
+    assert dataType != null : "dataType should not be null";
+    assert ordinal() < Byte.MAX_VALUE : format("ordinal() should be less than %d", Byte.MAX_VALUE);
+
+    this.dataType = dataType;
+    this.isNullable = isNullable;
+  }
+
+  @Override
+  public String getName() {
+    return name().toLowerCase();
+  }
+
+  @Override
+  public DataType getDataType() {
+    return dataType;
+  }
+
+  @Override
+  public byte getOrdinalPosition() {
+    return (byte) ordinal();
+  }
+
+  @Override
+  public boolean isNullable() {
+    return isNullable;
+  }
+
+}

--- a/src/main/java/edu/utdallas/davisbase/catalog/DavisBaseTablesTableColumn.java
+++ b/src/main/java/edu/utdallas/davisbase/catalog/DavisBaseTablesTableColumn.java
@@ -17,7 +17,6 @@ public enum DavisBaseTablesTableColumn implements CatalogTableColumn {
 
   private DavisBaseTablesTableColumn(DataType dataType, boolean isNullable) {
     assert dataType != null : "dataType should not be null";
-    assert ordinal() < Byte.MAX_VALUE : format("ordinal() should be less than %d", Byte.MAX_VALUE);
 
     this.dataType = dataType;
     this.isNullable = isNullable;
@@ -35,6 +34,8 @@ public enum DavisBaseTablesTableColumn implements CatalogTableColumn {
 
   @Override
   public byte getOrdinalPosition() {
+    assert ordinal() < Byte.MAX_VALUE : format("ordinal() should be less than %d", Byte.MAX_VALUE);
+
     return (byte) ordinal();
   }
 


### PR DESCRIPTION
Hard-code a *strongly-typed*, *immutable*, *structured*, and *modular* logical representation of the static DavisBase catalog tables and column schemas. This MAY be used anywhere in the project (e.g. storage initialization, compilation, execution, etc.), and SHOULD be used instead of _ad hoc_ literals and "magic strings".