### PR TITLE
Fix nullness warnings in command package

### DIFF
--- a/src/main/java/edu/utdallas/davisbase/command/CreateIndexCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/CreateIndexCommand.java
@@ -1,5 +1,6 @@
 package edu.utdallas.davisbase.command;
 
+@SuppressWarnings("nullness")  // COMBAK Unsuppress nullness warnings once we implement CreateIndexCommand.
 public class CreateIndexCommand implements Command {
 
   private String tableName;

--- a/src/main/java/edu/utdallas/davisbase/command/DeleteCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/DeleteCommand.java
@@ -1,5 +1,6 @@
 package edu.utdallas.davisbase.command;
 
+@SuppressWarnings("nullness")  // COMBAK Unsuppress nullness warnings once we implement DeleteCommand.
 public class DeleteCommand implements Command {
 
   private String tableName;

--- a/src/main/java/edu/utdallas/davisbase/command/DropTableCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/DropTableCommand.java
@@ -1,5 +1,6 @@
 package edu.utdallas.davisbase.command;
 
+@SuppressWarnings("nullness")  // COMBAK Unsuppress nullness warnings once we implement DropTableCommand.
 public class DropTableCommand implements Command {
 
   private String tableName;

--- a/src/main/java/edu/utdallas/davisbase/command/InsertCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/InsertCommand.java
@@ -29,6 +29,7 @@ public class InsertCommand implements Command {
    *                     null, not empty, every value must be either null or an instance of
    *                     {@link DataType#getJavaClass()} for one of the {@link DataType}s)
    */
+  @SuppressWarnings("nullness")  // Necessary because the ArrayList constructor is incorrectly annotated as requiring an argument of a @NonNull generic type, even though it can actually accept a collection argument with null elements.
   public InsertCommand(String tableName, int rowId, List<@Nullable Object> values) {
     checkNotNull(tableName, "tableName");
     checkElementIndex(rowId, Integer.MAX_VALUE, format("rowId %d is not in the range [0, %d)", rowId, Integer.MAX_VALUE));
@@ -74,7 +75,7 @@ public class InsertCommand implements Command {
    *         empty, every value is either null or an instance of {@link DataType#getJavaClass()} for
    *         one of the {@link DataType}s)
    */
-  public List<Object> getValues() {
+  public List<@Nullable Object> getValues() {
     return values;
   }
 

--- a/src/main/java/edu/utdallas/davisbase/command/UpdateCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/UpdateCommand.java
@@ -2,6 +2,7 @@ package edu.utdallas.davisbase.command;
 
 import java.util.List;
 
+@SuppressWarnings("nullness")  // COMBAK Unsuppress nullness warnings once we implement UpdateCommand.
 public class UpdateCommand implements Command {
 
   private String tableName;


### PR DESCRIPTION

Two types of causes:
- Unimplemented commands (for project part 2) with unintialized fields
- ArrayList constructors that incorrectly required a collection argument
  with nonnull generic type

Solution was to suppress each, but to add a COMBAK for the first to unsuppress once project part 2 is implemented.

As of this commit, the project builds without error given `mvn clean; mvn verify`.