### PR TITLE
`DROP TABLE`

### DIFF
--- a/src/main/java/edu/utdallas/davisbase/command/DropTableCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/DropTableCommand.java
@@ -7,6 +7,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class DropTableCommand implements Command {
 
+  // TODO Add field `indexNames: List<String>` (not null, no element null, may be empty) that lists
+  // the names of the indexes on the target table to drop; those indexes must be dropped as well.
+
+  // QUESTION Are indexes in DavisBase named? Or are they identified by table name plus column name?
+
   private final String tableName;
 
   /**

--- a/src/main/java/edu/utdallas/davisbase/command/DropTableCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/DropTableCommand.java
@@ -1,13 +1,50 @@
 package edu.utdallas.davisbase.command;
 
-@SuppressWarnings("nullness")  // COMBAK Unsuppress nullness warnings once we implement DropTableCommand.
+import static java.util.Objects.hash;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class DropTableCommand implements Command {
 
-  private String tableName;
+  private final String tableName;
 
-  // COMBAK Implement DropTableCommand
-
+  /**
+   * @param tableName the name of the table to drop (not null)
+   */
   public DropTableCommand(String tableName) {
+    checkNotNull(tableName, "tableName");
+
     this.tableName = tableName;
   }
+
+  /**
+   * @return the name of the table to drop (not null)
+   */
+  public String getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof DropTableCommand)) {
+      return false;
+    }
+
+    DropTableCommand other = (DropTableCommand) obj;
+    return getTableName().equals(other.getTableName());
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getTableName());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(DropTableCommand.class)
+        .add("tableName", getTableName())
+        .toString();
+  }
+
 }

--- a/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
+++ b/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
@@ -74,6 +74,7 @@ public class Compiler {
     }
     else if (command instanceof DeleteCommandRepresentation){
       DeleteCommandRepresentation delete= (DeleteCommandRepresentation)command;
+      validateNotCatalogTable(delete.getTable());
       return new DeleteCommand(
         delete.getTable(),
         compileCommandWhere(delete.getTable(), delete.getWhereClause())
@@ -81,6 +82,7 @@ public class Compiler {
     }
     else if (command instanceof DropTableCommandRepresentation){
       DropTableCommandRepresentation dropTable = (DropTableCommandRepresentation)command;
+      validateNotCatalogTable(dropTable.getTable());
       return new DropTableCommand(dropTable.getTable());
     }
     else if (command instanceof ExitCommandRepresentation){
@@ -88,6 +90,7 @@ public class Compiler {
     }
     else if (command instanceof InsertCommandRepresentation){
       InsertCommandRepresentation insert = (InsertCommandRepresentation)command;
+      validateNotCatalogTable(insert.getTable());
       List<InsertObject> insertObjects = new ArrayList<>();
       if(insert.getColumns().isEmpty()){
         for(int lcv = 0; lcv< insert.getValues().size(); lcv++){
@@ -139,6 +142,7 @@ public class Compiler {
     }
     else if (command instanceof UpdateCommandRepresentation){
       UpdateCommandRepresentation update = (UpdateCommandRepresentation)command;
+      validateNotCatalogTable(update.getTable());
       Column col = update.getColumn();
       byte colIndex =  getColumnIndex(col, update.getTable());
       UpdateCommandColumn updateCommandColumn = new UpdateCommandColumn(
@@ -600,6 +604,18 @@ public class Compiler {
         }
       default:
         throw new CompileException("Unrecognized operator");
+    }
+  }
+
+  /**
+   * Validate that the table name the command is trying to modify is not one of the catalog tables
+   * @param tableName name  of table to check
+   * @throws CompileException
+   */
+  private void validateNotCatalogTable(String tableName)throws CompileException{
+    if(tableName.equalsIgnoreCase(CatalogTable.DAVISBASE_COLUMNS.getName()) ||
+      tableName.equalsIgnoreCase(CatalogTable.DAVISBASE_TABLES.getName())){
+      throw new CompileException("Unable to modify catalog tables");
     }
   }
 

--- a/src/main/java/edu/utdallas/davisbase/executor/Executor.java
+++ b/src/main/java/edu/utdallas/davisbase/executor/Executor.java
@@ -198,6 +198,8 @@ public class Executor {
 
     final String commandTableName = command.getTableName();
 
+    // TODO Drop any indexes on the target table.
+
     context.deleteTableFile(commandTableName);
 
     try (final TableFile davisbaseTables = context.openTableFile(DAVISBASE_TABLES.getName())) {
@@ -234,6 +236,8 @@ public class Executor {
         }
       }
     }
+
+    // TODO Delete the catalog rows corresponding to the indexes (if any) on the target table.
 
     final DropTableResult result = new DropTableResult(commandTableName);
     return result;

--- a/src/main/java/edu/utdallas/davisbase/executor/Executor.java
+++ b/src/main/java/edu/utdallas/davisbase/executor/Executor.java
@@ -27,6 +27,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import edu.utdallas.davisbase.BooleanUtils;
 import edu.utdallas.davisbase.DataType;
 import edu.utdallas.davisbase.NotImplementedException;
+import edu.utdallas.davisbase.catalog.CatalogTable;
 import edu.utdallas.davisbase.catalog.DavisBaseColumnsTableColumn;
 import edu.utdallas.davisbase.catalog.DavisBaseTablesTableColumn;
 import edu.utdallas.davisbase.command.Command;
@@ -191,12 +192,51 @@ public class Executor {
     throw new NotImplementedException();
   }
 
-  protected DropTableResult executeDropTable(DropTableCommand command) throws ExecuteException, StorageException {
+  protected DropTableResult executeDropTable(DropTableCommand command) throws ExecuteException, StorageException, IOException {
     assert command != null : "command should not be null";
     assert context != null : "context should not be null";
 
-    // COMBAK Implement Executor.execute(DropTableCommand, Storage)
-    throw new NotImplementedException();
+    final String commandTableName = command.getTableName();
+
+    context.deleteTableFile(commandTableName);
+
+    try (final TableFile davisbaseTables = context.openTableFile(DAVISBASE_TABLES.getName())) {
+      while (davisbaseTables.goToNextRow()) {
+
+        final String rowTableName = castNonNull(
+            davisbaseTables.readText(DavisBaseTablesTableColumn.TABLE_NAME.getOrdinalPosition()));
+        assert rowTableName != null : "No row value for column 'table_name' in table 'davisbase_tables' should ever be null.";
+
+        if (rowTableName.equalsIgnoreCase(commandTableName)) {
+          davisbaseTables.removeRow();
+
+          // There should never be more than one row any given value of the 'table_name' column in the
+          // table 'davisbase_tables'. Therefore, we MAY break as soon as we've deleted the first
+          // matching row (if any).
+          break;
+        }
+      }
+    }
+
+    try (final TableFile davisbaseColumns = context.openTableFile(DAVISBASE_COLUMNS.getName())) {
+      while (davisbaseColumns.goToNextRow()) {
+
+        final String rowTableName = castNonNull(
+            davisbaseColumns.readText(DavisBaseColumnsTableColumn.TABLE_NAME.getOrdinalPosition()));
+        assert rowTableName != null : "No row value for column TABLE_NAME in table DAVISBASE_COLUMNS should ever be null.";
+
+        if (rowTableName.equalsIgnoreCase(commandTableName)) {
+          davisbaseColumns.removeRow();
+
+          // There can be multiple rows in the table DAVISBASE_COLUMNS for any given value of the
+          // column TABLE_NAME (i.e. a user-defined table can have multiple columns). Therefore, we
+          // MUST NOT break early, but rather MUST evaluate *every* row for possible removal.
+        }
+      }
+    }
+
+    final DropTableResult result = new DropTableResult(commandTableName);
+    return result;
   }
 
   protected ExitResult executeExit(ExitCommand command) throws ExecuteException, StorageException {

--- a/src/main/java/edu/utdallas/davisbase/result/DropTableResult.java
+++ b/src/main/java/edu/utdallas/davisbase/result/DropTableResult.java
@@ -1,10 +1,17 @@
 package edu.utdallas.davisbase.result;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.hash;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class DropTableResult implements Result {
+
+  // TODO Add field `indexNames: List<String>` (not null, no element null, may be empty) that lists
+  // the names of the indexes that were on the dropped table; those indexes should have been dropped
+  // as well.
+
+  // QUESTION Are indexes in DavisBase named? Or are they identified by table name plus column name?
 
   private final String tableName;
 

--- a/src/main/java/edu/utdallas/davisbase/storage/Storage.java
+++ b/src/main/java/edu/utdallas/davisbase/storage/Storage.java
@@ -3,17 +3,15 @@ package edu.utdallas.davisbase.storage;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.util.ArrayList;
 import java.util.List;
+
 import edu.utdallas.davisbase.BooleanUtils;
-import edu.utdallas.davisbase.NotImplementedException;
 import edu.utdallas.davisbase.catalog.CatalogTable;
 import edu.utdallas.davisbase.catalog.CatalogTableColumn;
-import edu.utdallas.davisbase.catalog.DavisBaseColumnsTableColumn;
-import edu.utdallas.davisbase.common.DavisBaseConstant;
 
 public class Storage {
 
@@ -21,10 +19,13 @@ public class Storage {
   private final StorageState state;
 
   @SuppressWarnings("initialization")
-
   public Storage(StorageConfiguration configuration, StorageState state) {
+    checkNotNull(configuration, "configuration");
+    checkNotNull(state, "state");
+
     this.configuration = configuration;
     this.state = state;
+
     initDavisBase();
   }
 

--- a/src/main/java/edu/utdallas/davisbase/storage/Storage.java
+++ b/src/main/java/edu/utdallas/davisbase/storage/Storage.java
@@ -47,9 +47,7 @@ public class Storage {
   public TableFile openTableFile(String tableName) throws IOException {
     checkNotNull(tableName);
 
-    final String tableFileName = tableName + "." + configuration.getTableFileExtension();
-    final File tableFileHandle = new File(state.getDataDirectory(), tableFileName);
-
+    final File tableFileHandle = getTableFileHandle(tableName);
     checkArgument(tableFileHandle.exists(), String.format(
         "File \"%s\" for table \"%s\" does not exist.", tableFileHandle.toString(), tableName));
     checkArgument(!tableFileHandle.isDirectory(),
@@ -62,6 +60,15 @@ public class Storage {
         "File length %d is not a multiple of page size %d.", length, configuration.getPageSize()));
 
     return new TableFile(randomAccessFile);
+  }
+
+  private File getTableFileHandle(String tableName) throws IOException {
+    assert tableName != null : "tableName should not be null";
+
+    final String tableFileName = tableName + "." + configuration.getTableFileExtension();
+    final File tableFileHandle = new File(state.getDataDirectory(), tableFileName);
+
+    return tableFileHandle;
   }
 
   public void initDavisBase() {

--- a/src/main/java/edu/utdallas/davisbase/storage/Storage.java
+++ b/src/main/java/edu/utdallas/davisbase/storage/Storage.java
@@ -1,9 +1,11 @@
 package edu.utdallas.davisbase.storage;
 
+import static java.lang.String.format;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.String.format;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -31,18 +33,15 @@ public class Storage {
   }
 
   public void createTableFile(String tableName) throws IOException {
+    checkNotNull(tableName, "tableName");
 
-    String path = state.getDataDirectory().getPath() + "/" + tableName + "."
-        + this.configuration.getTableFileExtension();
+    final File tableFileHandle = getTableFileHandle(tableName);
+    checkArgument(!tableFileHandle.exists(),
+        format("File '%s' for table '%s' already exists.",
+            tableFileHandle.toString(),
+            tableName));
 
-    File file = new File(path);
-
-    if (!file.exists()) {
-      RandomAccessFile table = new RandomAccessFile(state.getDataDirectory().getPath() + "/"
-          + tableName + "." + this.configuration.getTableFileExtension(), "rw");
-      // Page.addTableMetaDataPage(table);
-      table.close();
-    }
+    try (final RandomAccessFile randomAccessFile = new RandomAccessFile(tableFileHandle, "rw")) {}
   }
 
   public TableFile openTableFile(String tableName) throws IOException {


### PR DESCRIPTION
Implement the `DROP TABLE` command:

- `Executor#execute(DropTableCommand)`
- `Storage#deleteTableFile(tableName: String)`

Add `TODO` comments to come back and implement indexing logic for the following code elements after the index API interfaces and index catalog table/columns have been defined:

- `DropTableCommand`
- `Executor#execute(DropTableCommand)`
- `DropTableResult`

Also, internally refactor `Storage` by extracting disintegrated inline logic to the single private method `getTableFileHandle(tableName: String): File`.