### PR TITLE
`WHERE` clause compilation & execution

### DIFF
--- a/src/main/java/edu/utdallas/davisbase/command/CommandWhere.java
+++ b/src/main/java/edu/utdallas/davisbase/command/CommandWhere.java
@@ -3,6 +3,9 @@ package edu.utdallas.davisbase.command;
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.Objects.hash;
+
+import static org.checkerframework.checker.nullness.NullnessUtil.castNonNull;
+import java.util.Objects;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -39,9 +42,9 @@ public class CommandWhere {
   public CommandWhere(CommandWhereColumn leftColumnReference, Operator operator, @Nullable Object rightLiteralValue) {
     checkNotNull(leftColumnReference, "leftColumnReference");
     checkNotNull(operator, "operator");
-    checkArgument(rightLiteralValue == null || stream(DataType.values()).map(DataType::getJavaClass).anyMatch(cls -> rightLiteralValue.getClass().equals(cls)),
+    checkArgument(rightLiteralValue == null || stream(DataType.values()).map(DataType::getJavaClass).anyMatch(cls -> castNonNull(rightLiteralValue).getClass().equals(cls)),
         format("rightLiteralValue is an instance of %s, but must be either null or an instance of one of types defined by edu.utdallas.davisbase.DataType#getJavaClass()",
-            rightLiteralValue.getClass().getName()));
+            castNonNull(rightLiteralValue).getClass().getName()));
 
     this.leftColumnReference = leftColumnReference;
     this.operator = operator;
@@ -75,6 +78,7 @@ public class CommandWhere {
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public boolean equals(Object obj) {
     if (!(obj != null && obj instanceof CommandWhere)) {
       return false;
@@ -84,15 +88,17 @@ public class CommandWhere {
     return
         getLeftColumnReference() == other.getLeftColumnReference() &&
         getOperator().equals(other.getOperator()) &&
-        getRightLiteralValue().equals(other.getRightLiteralValue());
+        Objects.equals(getRightLiteralValue(), other.getRightLiteralValue());
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public int hashCode() {
     return hash(getLeftColumnReference(), getOperator(), getRightLiteralValue());
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public String toString() {
     return toStringHelper(CommandWhere.class)
         .add("leftColumnReference", getLeftColumnReference())

--- a/src/main/java/edu/utdallas/davisbase/command/CommandWhere.java
+++ b/src/main/java/edu/utdallas/davisbase/command/CommandWhere.java
@@ -1,0 +1,70 @@
+package edu.utdallas.davisbase.command;
+
+import static java.lang.String.format;
+import static java.util.Arrays.stream;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkElementIndex;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import edu.utdallas.davisbase.DataType;
+
+/**
+ * CommandWhere
+ */
+public class CommandWhere {
+
+  public static enum Operator {
+    EQUAL,
+    NOT_EQUAL,
+    GREATER_THAN,
+    GREATER_THAN_OR_EQUAL,
+    LESS_THAN,
+    LESS_THAN_OR_EQUAL;
+  }
+
+  private final byte leftColumnIndex;
+  private final Operator operator;
+  private final @NonNull Object rightLiteralValue;
+
+  public CommandWhere(byte leftColumnIndex, Operator operator, @NonNull Object rightLiteralValue) {
+    checkElementIndex(leftColumnIndex, Byte.MAX_VALUE,
+        format("leftColumnIndex %d must be in range [0, %d)", leftColumnIndex, Byte.MAX_VALUE));
+    checkNotNull(operator, "operator");
+    checkNotNull(rightLiteralValue, "rightLiteralValue");
+    checkArgument(stream(DataType.values()).map(DataType::getJavaClass).anyMatch(cls -> rightLiteralValue.getClass().equals(cls)),
+        format("rightLiteralValue is an instance of %s, which is not one of the types defined by edu.utdallas.davisbase.DataType#getJavaClass()", rightLiteralValue.getClass().getName()));
+
+    this.leftColumnIndex = leftColumnIndex;
+    this.operator = operator;
+    this.rightLiteralValue = rightLiteralValue;
+  }
+
+  /**
+   * @return the zero-based index of the column in the source table, where the column is the
+   *         referenced column on the left side of this simple {@code WHERE} clause expression (not
+   *         negative, and less than {@link java.lang.Byte#MAX_VALUE Byte.MAX_VALUE})
+   */
+  public byte getLeftColumnIndex() {
+    return leftColumnIndex;
+  }
+
+  /**
+   * @return the single binary relational {@link CommandWhere.Operator Operator} of this compiled
+   *         {@code WHERE} clause (not null)
+   */
+  public Operator getOperator() {
+    return operator;
+  }
+
+  /**
+   * @return the literal value on the right side of this simple {@code WHERE} clause expression (not
+   *         null, and an instance of one of the types defined by
+   *         {@link edu.utdallas.davisbase.DataType#getJavaClass() DataType.getJavaClass()})
+   */
+  public @NonNull Object getRightLiteralValue() {
+    return rightLiteralValue;
+  }
+
+}

--- a/src/main/java/edu/utdallas/davisbase/command/CommandWhere.java
+++ b/src/main/java/edu/utdallas/davisbase/command/CommandWhere.java
@@ -2,6 +2,8 @@ package edu.utdallas.davisbase.command;
 
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
+import static java.util.Objects.hash;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -10,9 +12,6 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 import edu.utdallas.davisbase.DataType;
 
-/**
- * CommandWhere
- */
 public class CommandWhere {
 
   public static enum Operator {
@@ -65,6 +64,33 @@ public class CommandWhere {
    */
   public @NonNull Object getRightLiteralValue() {
     return rightLiteralValue;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof CommandWhere)) {
+      return false;
+    }
+
+    CommandWhere other = (CommandWhere) obj;
+    return
+        getLeftColumnIndex() == other.getLeftColumnIndex() &&
+        getOperator().equals(other.getOperator()) &&
+        getRightLiteralValue().equals(other.getRightLiteralValue());
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getLeftColumnIndex(), getOperator(), getRightLiteralValue());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(CommandWhere.class)
+        .add("leftColumnIndex", getLeftColumnIndex())
+        .add("operator", getOperator())
+        .add("rightLiteralValue", getRightLiteralValue())
+        .toString();
   }
 
 }

--- a/src/main/java/edu/utdallas/davisbase/command/CommandWhere.java
+++ b/src/main/java/edu/utdallas/davisbase/command/CommandWhere.java
@@ -44,7 +44,7 @@ public class CommandWhere {
     checkNotNull(operator, "operator");
     checkArgument(rightLiteralValue == null || stream(DataType.values()).map(DataType::getJavaClass).anyMatch(cls -> castNonNull(rightLiteralValue).getClass().equals(cls)),
         format("rightLiteralValue is an instance of %s, but must be either null or an instance of one of types defined by edu.utdallas.davisbase.DataType#getJavaClass()",
-            castNonNull(rightLiteralValue).getClass().getName()));
+            rightLiteralValue == null ? "null" : castNonNull(rightLiteralValue).getClass().getName()));
 
     this.leftColumnReference = leftColumnReference;
     this.operator = operator;

--- a/src/main/java/edu/utdallas/davisbase/command/CommandWhereColumn.java
+++ b/src/main/java/edu/utdallas/davisbase/command/CommandWhereColumn.java
@@ -1,0 +1,114 @@
+package edu.utdallas.davisbase.command;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkElementIndex;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+import static java.util.Objects.hash;
+import edu.utdallas.davisbase.DataType;
+
+/**
+ * The specification of a column reference on the left side of a
+ * {@link edu.utdallas.davisbase.compiler.Compiler#compile(edu.utdallas.davisbase.representation.CommandRepresentation) compiled}
+ * simple {@link CommandWhere where} clause expression.
+ */
+public class CommandWhereColumn {
+
+  private final byte index;
+  private final String name;
+  private final DataType dataType;
+  private final boolean isNullable;
+  private final boolean hasIndexFile;
+
+  /**
+   * @param index        the zero-based index of the column in the source table (not negative, and
+   *                     less than {@link java.lang.Byte#MAX_VALUE Byte.MAX_VALUE})
+   * @param name         the name of the column in the source table (not null)
+   * @param dataType     the {@link DataType} of the column in the source table (not null)
+   * @param isNullable   whether the column accepts {@code null} values in the source table
+   * @param hasIndexFile whether the source {@code table.column} has an index file defined for it
+   *                     (e.g. as per the {@code CREATE INDEX} command)
+   */
+  public CommandWhereColumn(byte index, String name, DataType dataType, boolean isNullable, boolean hasIndexFile) {
+    checkElementIndex(index, Byte.MAX_VALUE,
+        format("index %d must be in range [0, %d)",
+            index, Byte.MAX_VALUE));
+    checkNotNull(name, "name");
+    checkNotNull(dataType , "dataType");
+
+    this.index = index;
+    this.name = name;
+    this.dataType = dataType;
+    this.isNullable = isNullable;
+    this.hasIndexFile = hasIndexFile;
+  }
+
+  /**
+   * @return the zero-based index of the column in the source table (not negative, and less than
+   *         {@link java.lang.Byte#MAX_VALUE Byte.MAX_VALUE})
+   */
+  public byte getIndex() {
+    return index;
+  }
+
+  /**
+   * @return the name of the column in the source table (not null)
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @return the {@link DataType} of the column in the source table (not null)
+   */
+  public DataType getDataType() {
+    return dataType;
+  }
+
+  /**
+   * @return whether the column in the source table accepts {@code null} values
+   */
+  public boolean isNullable() {
+    return isNullable;
+  }
+
+  /**
+   * @return whether the source {@code table.column} has an index file defined for it (e.g. as per
+   *         the {@code CREATE INDEX} command)
+   */
+  public boolean hasIndexFile() {
+    return hasIndexFile;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof CommandWhereColumn)) {
+      return false;
+    }
+
+    CommandWhereColumn other = (CommandWhereColumn) obj;
+    return
+        getIndex() == other.getIndex() &&
+        getName().equals(other.getName()) &&
+        getDataType().equals(other.getDataType()) &&
+        isNullable() == other.isNullable() &&
+        hasIndexFile() == other.hasIndexFile();
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getIndex(), getName(), getDataType(), isNullable(), hasIndexFile());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(CommandWhereColumn.class)
+        .add("index", getIndex())
+        .add("name", getName())
+        .add("dataType", getDataType())
+        .add("isNullable", isNullable())
+        .add("hasIndexFile", hasIndexFile())
+        .toString();
+  }
+
+}

--- a/src/main/java/edu/utdallas/davisbase/command/DeleteCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/DeleteCommand.java
@@ -4,7 +4,7 @@ package edu.utdallas.davisbase.command;
 public class DeleteCommand implements Command {
 
   private String tableName;
-  // QUESTION How should the where expression be represented?
+  // TODO Implement DeleteCommand.wherePredicate
 
   // COMBAK Implement DeleteCommand
 

--- a/src/main/java/edu/utdallas/davisbase/command/DeleteCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/DeleteCommand.java
@@ -3,6 +3,7 @@ package edu.utdallas.davisbase.command;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.hash;
+import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class DeleteCommand implements Command {
@@ -33,6 +34,7 @@ public class DeleteCommand implements Command {
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public boolean equals(Object obj) {
     if (!(obj != null && obj instanceof DeleteCommand)) {
       return false;
@@ -40,24 +42,18 @@ public class DeleteCommand implements Command {
 
     DeleteCommand other = (DeleteCommand) obj;
     return
-        getTableName().equals(other.getTableName()) && (
-          (
-            getWhere() == null &&
-            other.getWhere() == null
-          ) || (
-            getWhere() != null &&
-            other.getWhere() != null
-            && getWhere().equals(other.getWhere())
-          )
-        );
+        getTableName().equals(other.getTableName()) &&
+        Objects.equals(getWhere(), other.getWhere());
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public int hashCode() {
     return hash(getTableName(), getWhere());
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public String toString() {
     return toStringHelper(DeleteCommand.class)
         .add("tableName", getTableName())

--- a/src/main/java/edu/utdallas/davisbase/command/DeleteCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/DeleteCommand.java
@@ -1,14 +1,68 @@
 package edu.utdallas.davisbase.command;
 
-@SuppressWarnings("nullness")  // COMBAK Unsuppress nullness warnings once we implement DeleteCommand.
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.hash;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public class DeleteCommand implements Command {
 
-  private String tableName;
-  // TODO Implement DeleteCommand.wherePredicate
+  private final String tableName;
+  private final @Nullable CommandWhere where;
 
-  // COMBAK Implement DeleteCommand
+  public DeleteCommand(String tableName, @Nullable CommandWhere where) {
+    checkNotNull(tableName, "tableName");
 
-  public DeleteCommand(String tableName) {
     this.tableName = tableName;
+    this.where = where;
   }
+
+  /**
+   * @return the name of the table from which to delete (not null)
+   */
+  public String getTableName() {
+    return tableName;
+  }
+
+  /**
+   * @return the specification of the simple {@code WHERE} clause expression of this command, if any
+   *         (nullable)
+   */
+  public @Nullable CommandWhere getWhere() {
+    return where;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof DeleteCommand)) {
+      return false;
+    }
+
+    DeleteCommand other = (DeleteCommand) obj;
+    return
+        getTableName().equals(other.getTableName()) && (
+          (
+            getWhere() == null &&
+            other.getWhere() == null
+          ) || (
+            getWhere() != null &&
+            other.getWhere() != null
+            && getWhere().equals(other.getWhere())
+          )
+        );
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getTableName(), getWhere());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(DeleteCommand.class)
+        .add("tableName", getTableName())
+        .add("where", getWhere())
+        .toString();
+  }
+
 }

--- a/src/main/java/edu/utdallas/davisbase/command/SelectCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/SelectCommand.java
@@ -7,6 +7,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.hash;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class SelectCommand implements Command {
@@ -62,6 +63,7 @@ public class SelectCommand implements Command {
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public boolean equals(Object obj) {
     if (!(obj != null && obj instanceof SelectCommand)) {
       return false;
@@ -70,24 +72,18 @@ public class SelectCommand implements Command {
     SelectCommand other = (SelectCommand) obj;
     return
         tableName.equals(other.getTableName()) &&
-        selectClauseColumns.equals(other.getSelectClauseColumns()) && (
-          (
-            getWhere() == null &&
-            other.getWhere() == null
-          ) || (
-            getWhere() != null &&
-            other.getWhere() != null &&
-            getWhere().equals(other.getWhere())
-          )
-        );
+        selectClauseColumns.equals(other.getSelectClauseColumns()) &&
+        Objects.equals(getWhere(), other.getWhere());
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public int hashCode() {
     return hash(getTableName(), getSelectClauseColumns(), getWhere());
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public String toString() {
     return toStringHelper(SelectCommand.class)
         .add("tableName", getTableName())

--- a/src/main/java/edu/utdallas/davisbase/command/SelectCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/SelectCommand.java
@@ -12,7 +12,7 @@ public class SelectCommand implements Command {
 
   private final String tableName;
   private final List<SelectCommandColumn> selectClauseColumns;
-  // COMBAK Implement Command.whereExpression fields
+  // TODO Implement SelectCommand.wherePredicate
 
   /**
    * @param tableName           the name of the table being selected FROM (not null)

--- a/src/main/java/edu/utdallas/davisbase/command/UpdateCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/UpdateCommand.java
@@ -71,7 +71,7 @@ public class UpdateCommand implements Command {
    * @return the simple {@link CommandWhere where} clause expression for this {@code UpdateCommand},
    *         if any (nullable)
    */
-  public CommandWhere getWhere() {
+  public @Nullable CommandWhere getWhere() {
     return where;
   }
 

--- a/src/main/java/edu/utdallas/davisbase/command/UpdateCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/UpdateCommand.java
@@ -11,6 +11,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -76,6 +77,7 @@ public class UpdateCommand implements Command {
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public boolean equals(Object obj) {
     if (!(obj != null && obj instanceof UpdateCommand)) {
       return false;
@@ -84,24 +86,18 @@ public class UpdateCommand implements Command {
     UpdateCommand other = (UpdateCommand) obj;
     return
         getTableName().equals(other.getTableName()) &&
-        getColumns().equals(other.getColumns()) && (
-          (
-            getWhere() == null &&
-            other.getWhere() == null
-          ) || (
-            getWhere() != null &&
-            other.getWhere() != null &&
-            getWhere().equals(other.getWhere())
-          )
-        );
+        getColumns().equals(other.getColumns()) &&
+        Objects.equals(getWhere(), other.getWhere());
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public int hashCode() {
     return hash(getTableName(), getColumns(), getWhere());
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public String toString() {
     return toStringHelper(UpdateCommand.class)
         .add("tableName", getTableName())

--- a/src/main/java/edu/utdallas/davisbase/command/UpdateCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/UpdateCommand.java
@@ -1,20 +1,113 @@
 package edu.utdallas.davisbase.command;
 
-import java.util.List;
+import static java.lang.String.format;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.hash;
 
-@SuppressWarnings("nullness")  // COMBAK Unsuppress nullness warnings once we implement UpdateCommand.
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public class UpdateCommand implements Command {
 
-  private String tableName;
-  private List<String> columnIds;  // COMBAK Split columnIds field into a list column name strings and a list of column id bytes.
-  private List<String> values;  // COMBAK Refactor values field to use structured objects vs. raw strings.
-  // TODO Implement UpdateCommand.wherePredicate
+  private final String tableName;
+  private final List<UpdateCommandColumn> columns;
+  private final @Nullable CommandWhere where;
 
-  // COMBAK Implement UpdateCommand
+  // TODO Implement fields in UpdateCommand for whether a size change could occur (e.g. an update
+  // column is nullable, an updated column is of type TEXT, etc.)
 
-  public UpdateCommand(String tableName, List<String> columnIds, List<String> values) {
+  /**
+   * @param tableName the name of the table to update
+   * @param columns   the unordered collection of (nonnull) column-index-value specifications that
+   *                  make up this {@code UpdateCommand}, where each {@code UpdateCommandColumn}
+   *                  returns a distinct value for {@link UpdateCommandColumn#getColumnIndex()} (not
+   *                  null, not empty)
+   * @param where     the specification of the simple {@link CommandWhere where} clause expression
+   *                  for this {@code UpdateCommand}, if any (nullable)
+   */
+  public UpdateCommand(String tableName, List<UpdateCommandColumn> columns, @Nullable CommandWhere where) {
+    checkNotNull(tableName, "tableName");
+    checkNotNull(columns, "columns");
+    checkArgument(!columns.isEmpty(), "columns should not be empty");
+    final Set<Byte> columnIndexes = new HashSet<>(columns.size());
+    for (int i = 0; i < columns.size(); i++) {
+      checkNotNull(columns.get(i), format("columns.get(%d) should not be null", i));
+      checkArgument(columnIndexes.add(columns.get(i).getColumnIndex()),
+          format("Duplicate column index %d detected in columns at column.get(%d)",
+              columns.get(i).getColumnIndex(), i));
+    }
+
     this.tableName = tableName;
-    this.columnIds = columnIds;
-    this.values = values;
+    this.columns = unmodifiableList(new ArrayList<>(columns));
+    this.where = where;
   }
+
+  /**
+   * @return the name of the table to update (not null)
+   */
+  public String getTableName() {
+    return tableName;
+  }
+
+  /**
+   * @return an unmodifiable view of the list of (nonnull) column-index-value specifications that
+   *         make up this {@code UpdateCommand}, where the order of the returned list is not
+   *         significant, and each {@link UpdateCommandColumn} has a distinct value for
+   *         {@link UpdateCommandColumn#getColumnIndex()} (not null, not empty)
+   */
+  public List<UpdateCommandColumn> getColumns() {
+    return columns;
+  }
+
+  /**
+   * @return the simple {@link CommandWhere where} clause expression for this {@code UpdateCommand},
+   *         if any (nullable)
+   */
+  public CommandWhere getWhere() {
+    return where;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof UpdateCommand)) {
+      return false;
+    }
+
+    UpdateCommand other = (UpdateCommand) obj;
+    return
+        getTableName().equals(other.getTableName()) &&
+        getColumns().equals(other.getColumns()) && (
+          (
+            getWhere() == null &&
+            other.getWhere() == null
+          ) || (
+            getWhere() != null &&
+            other.getWhere() != null &&
+            getWhere().equals(other.getWhere())
+          )
+        );
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getTableName(), getColumns(), getWhere());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(UpdateCommand.class)
+        .add("tableName", getTableName())
+        .add("columns", getColumns())
+        .add("where", getWhere())
+        .toString();
+  }
+
 }

--- a/src/main/java/edu/utdallas/davisbase/command/UpdateCommand.java
+++ b/src/main/java/edu/utdallas/davisbase/command/UpdateCommand.java
@@ -8,7 +8,7 @@ public class UpdateCommand implements Command {
   private String tableName;
   private List<String> columnIds;  // COMBAK Split columnIds field into a list column name strings and a list of column id bytes.
   private List<String> values;  // COMBAK Refactor values field to use structured objects vs. raw strings.
-  // QUESTION How should the where expression be represented?
+  // TODO Implement UpdateCommand.wherePredicate
 
   // COMBAK Implement UpdateCommand
 

--- a/src/main/java/edu/utdallas/davisbase/command/UpdateCommandColumn.java
+++ b/src/main/java/edu/utdallas/davisbase/command/UpdateCommandColumn.java
@@ -4,6 +4,8 @@ import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.Objects.hash;
 
+import static org.checkerframework.checker.nullness.NullnessUtil.castNonNull;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -32,7 +34,7 @@ public class UpdateCommandColumn {
   public UpdateCommandColumn(byte columnIndex, @Nullable Object value) {
     checkArgument(1 <= columnIndex && columnIndex < Byte.MAX_VALUE,
         format("columnIndex %d should be in the range [1, %d)", columnIndex, Byte.MAX_VALUE));
-    checkArgument(value != null || stream(DataType.values()).map(DataType::getJavaClass).anyMatch(cls -> value.getClass().equals(cls)),
+    checkArgument(value != null || stream(DataType.values()).map(DataType::getJavaClass).anyMatch(cls -> castNonNull(value).getClass().equals(cls)),
         "value should be either null or an instance of one of edu.utdallas.davisbase.Datatype#getJavaClass()");
 
     this.columnIndex = columnIndex;
@@ -57,6 +59,7 @@ public class UpdateCommandColumn {
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public boolean equals(Object obj) {
     if (!(obj != null && obj instanceof UpdateCommandColumn)) {
       return false;
@@ -69,11 +72,13 @@ public class UpdateCommandColumn {
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public int hashCode() {
     return hash(getColumnIndex(), getValue());
   }
 
   @Override
+  @SuppressWarnings("nullness")
   public String toString() {
     return toStringHelper(UpdateCommandColumn.class)
         .add("columnIndex", getColumnIndex())

--- a/src/main/java/edu/utdallas/davisbase/command/UpdateCommandColumn.java
+++ b/src/main/java/edu/utdallas/davisbase/command/UpdateCommandColumn.java
@@ -1,0 +1,84 @@
+package edu.utdallas.davisbase.command;
+
+import static java.lang.String.format;
+import static java.util.Arrays.stream;
+import static java.util.Objects.hash;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Objects;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import edu.utdallas.davisbase.DataType;
+
+/**
+ * The specification of a column to update (including the value to update it to) for a
+ * {@link UpdateCommand}.
+ */
+public class UpdateCommandColumn {
+
+  private final byte columnIndex;
+  private final @Nullable Object value;
+
+  /**
+   * @param columnIndex the zero-based index of the column in the source table to update (positive,
+   *                    less than {@link java.lang.Byte#MAX_VALUE Byte.MAX_VALUE})
+   * @param value       the literal value to which to assign to the column (either {@code null} or
+   *                    an instance of the class returned by {@link DataType#getJavaClass()} for one
+   *                    of the {@link DataType}s)
+   */
+  public UpdateCommandColumn(byte columnIndex, @Nullable Object value) {
+    checkArgument(1 <= columnIndex && columnIndex < Byte.MAX_VALUE,
+        format("columnIndex %d should be in the range [1, %d)", columnIndex, Byte.MAX_VALUE));
+    checkArgument(value != null || stream(DataType.values()).map(DataType::getJavaClass).anyMatch(cls -> value.getClass().equals(cls)),
+        "value should be either null or an instance of one of edu.utdallas.davisbase.Datatype#getJavaClass()");
+
+    this.columnIndex = columnIndex;
+    this.value = value;
+  }
+
+  /**
+   * @return the zero-based index of the column in the source table to update (positive, less than
+   *         {@link java.lang.Byte#MAX_VALUE Byte.MAX_VALUE})
+   */
+  public byte getColumnIndex() {
+    return columnIndex;
+  }
+
+  /**
+   * @return the literal value to which to assign to the column (either {@code null} or an instance
+   *         of the class returned by {@link DataType#getJavaClass()} for one of the
+   *         {@link DataType}s)
+   */
+  public @Nullable Object getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj != null && obj instanceof UpdateCommandColumn)) {
+      return false;
+    }
+
+    UpdateCommandColumn other = (UpdateCommandColumn) obj;
+    return
+        getColumnIndex() == other.getColumnIndex() &&
+        Objects.equals(getValue(), other.getValue());
+  }
+
+  @Override
+  public int hashCode() {
+    return hash(getColumnIndex(), getValue());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(UpdateCommandColumn.class)
+        .add("columnIndex", getColumnIndex())
+        .add("value", getValue())
+        .toString();
+  }
+
+}

--- a/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
+++ b/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
@@ -354,7 +354,7 @@ public class Compiler {
           return castNonNull(table.readTinyInt(DavisBaseColumnsTableColumn.ORDINAL_POSITION.getOrdinalPosition()));
         }
       }
-      throw new CompileException("Column does not exist within this table");
+      throw new CompileException("Column " +columnName + " does not exist within this table");
   }
 
   /**
@@ -369,7 +369,7 @@ public class Compiler {
         return tableName;
       }
     }
-    throw new CompileException("Table does not exist within DavisBase");
+    throw new CompileException("Table" +tableName+ " does not exist within DavisBase");
   }
 
   /**
@@ -386,7 +386,7 @@ public class Compiler {
         return DataType.valueOf(castNonNull(table.readText(DavisBaseColumnsTableColumn.DATA_TYPE.getOrdinalPosition())));
       }
     }
-    throw new CompileException("Column does not exist within this table");
+    throw new CompileException("Column " +columnName + " does not exist within this table");
   }
 
   public String getColumnName(String tableName, int columnIndex)throws CompileException, StorageException, IOException{
@@ -397,7 +397,7 @@ public class Compiler {
         return (castNonNull(table.readText(DavisBaseColumnsTableColumn.COLUMN_NAME.getOrdinalPosition())));
       }
     }
-    throw new CompileException("Column does not exist within this table");
+    throw new CompileException("Column with index " + columnIndex + " does not exist within this table");
   }
 
   /**
@@ -458,7 +458,7 @@ public class Compiler {
     TableFile table  = context.openTableFile(CatalogTable.DAVISBASE_TABLES.getName());
     while(table.goToNextRow()){
       if(castNonNull(table.readText(DavisBaseTablesTableColumn.TABLE_NAME.getOrdinalPosition())).equalsIgnoreCase(tableName)) {
-        throw new CompileException("Table already exists.");
+        throw new CompileException("Table " +tableName+ " already exists.");
       }
     }
   }
@@ -500,7 +500,7 @@ public class Compiler {
         return BooleanUtils.fromText(castNonNull(table.readText(DavisBaseColumnsTableColumn.IS_NULLABLE.getOrdinalPosition())));
       }
     }
-    throw new CompileException("Column does not exist within this table");
+    throw new CompileException("Column " + columnName + " does not exist within this table");
   }
 
   /**

--- a/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
+++ b/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
@@ -435,10 +435,25 @@ public class Compiler {
     throw new CompileException("Values you are trying to insert does not match the table schema");
   }
 
+  /**
+   * @param col Column object to check
+   * @param table table name to check column
+   * @return byte of column index based on parameters
+   * @throws CompileException
+   * @throws StorageException
+   * @throws IOException
+   */
   public byte getColumnIndex(Column col, String table)throws CompileException,StorageException, IOException{
     return (validateIsDavisBaseColumnWithinTable(table, col.getColumnName()));
   }
 
+  /**
+   * Validate that given table exists otherwise throws exception
+   * @param tableName table to check existence
+   * @throws CompileException
+   * @throws StorageException
+   * @throws IOException
+   */
   public void validateTableDoesNotExist(String tableName)throws CompileException, StorageException, IOException{
     TableFile table  = context.openTableFile(CatalogTable.DAVISBASE_TABLES.getName());
     while(table.goToNextRow()){
@@ -448,6 +463,16 @@ public class Compiler {
     }
   }
 
+  /**
+   * Validate the nullability of an expression
+   * @param tableName table of column
+   * @param columnName column to check
+   * @param value Expression to check value of
+   * @return
+   * @throws CompileException
+   * @throws StorageException
+   * @throws IOException
+   */
   public boolean validateNullability(String tableName, String columnName, Expression value)throws CompileException, StorageException, IOException{
     if(getIsNullable(tableName, columnName) && value instanceof NullValue){
       return true;
@@ -458,6 +483,15 @@ public class Compiler {
     return false;
   }
 
+  /**
+   * Checks against DAVISBASE_COLUMNS table to see if column is nullable
+   * @param tableName table to check
+   * @param columnName column to check
+   * @return whether column nullable
+   * @throws CompileException
+   * @throws StorageException
+   * @throws IOException
+   */
   public boolean getIsNullable(String tableName, String columnName)throws CompileException, StorageException, IOException {
     TableFile table  = context.openTableFile(CatalogTable.DAVISBASE_COLUMNS.getName());
     while(table.goToNextRow()){
@@ -469,6 +503,12 @@ public class Compiler {
     throw new CompileException("Column does not exist within this table");
   }
 
+  /**
+   * @param tableName table to get columns
+   * @return List of SelectCommandColumn object that represents all columns for given table
+   * @throws StorageException
+   * @throws IOException
+   */
   public List<SelectCommandColumn> getAllColumns(String tableName)throws StorageException, IOException{
     List<SelectCommandColumn> selectColumns = new ArrayList<>();
     TableFile table  = context.openTableFile(CatalogTable.DAVISBASE_COLUMNS.getName());
@@ -485,6 +525,14 @@ public class Compiler {
     return selectColumns;
   }
 
+  /**
+   * @param tableName name of table
+   * @param where WhereExpression representation of where clause
+   * @return compiled CommandWhere of where clause
+   * @throws IOException
+   * @throws StorageException
+   * @throws CompileException
+   */
   public @Nullable CommandWhere compileCommandWhere(String tableName, @Nullable WhereExpression where)throws IOException, StorageException,CompileException{
     if(null==where){
       return null;
@@ -505,6 +553,11 @@ public class Compiler {
     );
   }
 
+  /**
+   * @param op WhereExpression Operator enum
+   * @return the CommandWhere Operator Enum given the WhereExpression Operator
+   * @throws CompileException
+   */
   public CommandWhere.Operator returnCommandOperator(WhereExpression.Operator op)throws CompileException{
     switch (op){
       case EQUALSTO:

--- a/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
+++ b/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
@@ -73,7 +73,7 @@ public class Compiler {
       DeleteCommandRepresentation delete= (DeleteCommandRepresentation)command;
       return new DeleteCommand(
         delete.getTable(),
-        parseCommandWhere(delete.getTable(), delete.getWhereClause())
+        compileCommandWhere(delete.getTable(), delete.getWhereClause())
       );
     }
     else if (command instanceof DropTableCommandRepresentation){
@@ -128,7 +128,7 @@ public class Compiler {
       return new SelectCommand(
         validateIsDavisBaseTable(select.getTable()),
         selectColumns,
-        parseCommandWhere(select.getTable(),select.getWhereClause())
+        compileCommandWhere(select.getTable(),select.getWhereClause())
       );
     }
     else if (command instanceof ShowTablesCommandRepresentation){
@@ -151,7 +151,7 @@ public class Compiler {
       return new UpdateCommand(
         update.getTable(),
         updateCommandColumns,
-        parseCommandWhere(update.getTable(), update.getWhereClause())
+        compileCommandWhere(update.getTable(), update.getWhereClause())
       );
     }
     else{
@@ -485,7 +485,7 @@ public class Compiler {
     return selectColumns;
   }
 
-  public @Nullable CommandWhere parseCommandWhere(String tableName, @Nullable WhereExpression where)throws IOException, StorageException,CompileException{
+  public @Nullable CommandWhere compileCommandWhere(String tableName, @Nullable WhereExpression where)throws IOException, StorageException,CompileException{
     if(null==where){
       return null;
     }

--- a/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
+++ b/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
@@ -73,7 +73,7 @@ public class Compiler {
       DeleteCommandRepresentation delete= (DeleteCommandRepresentation)command;
       return new DeleteCommand(
         delete.getTable(),
-        parseCommandWhere(delete.getWhereClause())
+        parseCommandWhere(delete.getTable(), delete.getWhereClause())
       );
     }
     else if (command instanceof DropTableCommandRepresentation){
@@ -151,7 +151,7 @@ public class Compiler {
       return new UpdateCommand(
         update.getTable(),
         updateCommandColumns,
-        parseCommandWhere(update.getWhereClause())
+        parseCommandWhere(update.getTable(), update.getWhereClause())
       );
     }
     else{

--- a/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
+++ b/src/main/java/edu/utdallas/davisbase/compiler/Compiler.java
@@ -548,7 +548,7 @@ public class Compiler {
     );
     return new CommandWhere(
       leftColumnReference,
-      returnCommandOperator(where.getOperator()),
+      returnCommandOperator(where.getOperator(), where.isNot()),
       validateTypeMatchesSchema(tableName, where.getValue(), columnName)
     );
   }
@@ -558,20 +558,49 @@ public class Compiler {
    * @return the CommandWhere Operator Enum given the WhereExpression Operator
    * @throws CompileException
    */
-  public CommandWhere.Operator returnCommandOperator(WhereExpression.Operator op)throws CompileException{
+  public CommandWhere.Operator returnCommandOperator(WhereExpression.Operator op, boolean isNot)throws CompileException{
     switch (op){
       case EQUALSTO:
-        return CommandWhere.Operator.EQUAL;
+        if(isNot){
+          return CommandWhere.Operator.NOT_EQUAL;
+        }else{
+          return CommandWhere.Operator.EQUAL;
+        }
       case NOTEQUALTO:
-        return CommandWhere.Operator.NOT_EQUAL;
+        if(isNot){
+          return CommandWhere.Operator.EQUAL;
+        }
+        else{
+          return CommandWhere.Operator.NOT_EQUAL;
+        }
       case GREATERTHAN:
-        return CommandWhere.Operator.GREATER_THAN;
+        if(isNot){
+          return CommandWhere.Operator.LESS_THAN_OR_EQUAL;
+        }
+        else{
+          return CommandWhere.Operator.GREATER_THAN;
+        }
       case GREATERTHANEQUALS:
-        return CommandWhere.Operator.GREATER_THAN_OR_EQUAL;
+        if(isNot){
+          return CommandWhere.Operator.LESS_THAN;
+        }
+        else{
+          return CommandWhere.Operator.GREATER_THAN_OR_EQUAL;
+        }
       case LESSTHAN:
-        return CommandWhere.Operator.LESS_THAN;
+        if(isNot){
+          return CommandWhere.Operator.GREATER_THAN_OR_EQUAL;
+        }
+        else{
+          return CommandWhere.Operator.LESS_THAN;
+        }
       case LESSTHANEQUALS:
-        return CommandWhere.Operator.LESS_THAN_OR_EQUAL;
+        if(isNot){
+          return CommandWhere.Operator.GREATER_THAN;
+        }
+        else{
+          return CommandWhere.Operator.LESS_THAN_OR_EQUAL;
+        }
       default:
         throw new CompileException("Unrecognized operator");
     }

--- a/src/main/java/edu/utdallas/davisbase/executor/Executor.java
+++ b/src/main/java/edu/utdallas/davisbase/executor/Executor.java
@@ -181,6 +181,7 @@ public class Executor {
     return result;
   }
 
+  // TODO Implement support for WHERE in method executeDeleteCommand(*)
   protected DeleteResult executeDelete(DeleteCommand command, Storage context) throws ExecuteException, StorageException {
     assert command != null : "command should not be null";
     assert context != null : "context should not be null";
@@ -260,6 +261,7 @@ public class Executor {
     return result;
   }
 
+  // TODO Implement support for WHERE in method executeSelectCommand(*)
   protected SelectResult executeSelectCommand(SelectCommand command, Storage context) throws ExecuteException, StorageException, IOException {
     assert command != null : "command should not be null";
     assert context != null : "context should not be null";
@@ -374,6 +376,7 @@ public class Executor {
     return result;
   }
 
+  // TODO Implement support for WHERE in method executeUpdateCommand(*)
   protected UpdateResult executeUpdate(UpdateCommand command, Storage context) throws ExecuteException, StorageException {
     assert command != null : "command should not be null";
     assert context != null : "context should not be null";

--- a/src/main/java/edu/utdallas/davisbase/executor/Executor.java
+++ b/src/main/java/edu/utdallas/davisbase/executor/Executor.java
@@ -20,7 +20,7 @@ import java.time.LocalTime;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.List;
-
+import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -30,6 +30,8 @@ import edu.utdallas.davisbase.NotImplementedException;
 import edu.utdallas.davisbase.catalog.DavisBaseColumnsTableColumn;
 import edu.utdallas.davisbase.catalog.DavisBaseTablesTableColumn;
 import edu.utdallas.davisbase.command.Command;
+import edu.utdallas.davisbase.command.CommandWhere;
+import edu.utdallas.davisbase.command.CommandWhereColumn;
 import edu.utdallas.davisbase.command.CreateIndexCommand;
 import edu.utdallas.davisbase.command.CreateTableCommand;
 import edu.utdallas.davisbase.command.CreateTableCommandColumn;
@@ -385,6 +387,205 @@ public class Executor {
 
     // COMBAK Implement Executor.execute(UpdateCommand, Storage)
     throw new NotImplementedException();
+  }
+
+  private @Nullable Object readValue(byte columnIndex, DataType dataType, TableFile tableFile) throws StorageException, IOException {
+    assert 0 <= columnIndex && columnIndex < Byte.MAX_VALUE : format("columnIndex %d should be in range [0, %d)", columnIndex, Byte.MAX_VALUE);
+    assert dataType != null : "dataType should not be null";
+    assert tableFile != null : "tableFile should not be null";
+
+    @Nullable Object value;
+    switch (dataType) {
+      case TINYINT:
+        value = tableFile.readTinyInt(columnIndex);
+        break;
+
+      case SMALLINT:
+        value = tableFile.readSmallInt(columnIndex);
+        break;
+
+      case INT:
+        value = tableFile.readInt(columnIndex);
+        break;
+
+      case BIGINT:
+        value = tableFile.readBigInt(columnIndex);
+        break;
+
+      case FLOAT:
+        value = tableFile.readFloat(columnIndex);
+        break;
+
+      case DOUBLE:
+        value = tableFile.readDouble(columnIndex);
+        break;
+
+      case YEAR:
+        value = tableFile.readYear(columnIndex);
+        break;
+
+      case TIME:
+        value = tableFile.readTime(columnIndex);
+        break;
+
+      case DATETIME:
+        value = tableFile.readDateTime(columnIndex);
+        break;
+
+      case DATE:
+        value = tableFile.readDate(columnIndex);
+        break;
+
+      case TEXT:
+        value = tableFile.readText(columnIndex);
+        break;
+
+      default:
+        throw new NotImplementedException(format("edu.utdallas.davisbase.executor.Executor#readValue(byte, DataType, TableFile) for DataType %s", dataType));
+    }
+    return value;
+  }
+
+  private boolean evaluateWhere(CommandWhere where, TableFile tableFile) throws ExecuteException, StorageException, IOException {
+    assert where != null : "where should not be null";
+    assert !where.getLeftColumnReference().hasIndexFile() : "where.getLeftColumnReference().hasIndexFile() should be false";
+    assert tableFile != null : "tableFile should not be null";
+
+    final CommandWhereColumn leftColumn = where.getLeftColumnReference();
+    final byte leftColumnIndex = leftColumn.getIndex();
+    final DataType leftColumnDataType = leftColumn.getDataType();
+
+    final @Nullable Object leftValue = readValue(leftColumnIndex, leftColumnDataType, tableFile);
+    final @Nullable Object rightValue = where.getRightLiteralValue();
+
+    switch (where.getOperator()) {
+      case EQUAL:
+        return evaluateWhereEqual(leftColumnDataType, leftValue, rightValue);
+
+      case NOT_EQUAL:
+        return evaluateWhereNotEqual(leftColumnDataType, leftValue, rightValue);
+
+      case GREATER_THAN:
+        return evaluateWhereGreaterThan(leftColumnDataType, leftValue, rightValue);
+
+      case GREATER_THAN_OR_EQUAL:
+        return evaluateWhereGreaterThanOrEqual(leftColumnDataType, leftValue, rightValue);
+
+      case LESS_THAN:
+        return evaluateWhereLessThan(leftColumnDataType, leftValue, rightValue);
+
+      case LESS_THAN_OR_EQUAL:
+        return evaluateWhereLessThanOrEqual(leftColumnDataType, leftValue, rightValue);
+
+      default:
+        throw new NotImplementedException(format("edu.utdallas.davisbase.executor.Executor#evaluateWhereTable(CommandWhere, TableFile) for type edu.utdallas.davisbase.command.CommandWhere.Operator#%s", where.getOperator()));
+    }
+  }
+
+  private int evaluateComparison(DataType dataType, Object leftValue, Object rightValue) {
+    assert dataType != null : "dataType should not be null";
+    assert leftValue != null : "leftValue should not be null";
+    assert rightValue != null : "rightValue should not be null";
+
+    switch (dataType) {
+      case TINYINT:
+        return ((Byte) leftValue).compareTo((Byte) rightValue);
+
+      case SMALLINT:
+        return ((Short) leftValue).compareTo((Short) rightValue);
+
+      case INT:
+        return ((Integer) leftValue).compareTo((Integer) rightValue);
+
+      case BIGINT:
+        return ((Long) leftValue).compareTo((Long) rightValue);
+
+      case FLOAT:
+        return ((Float) leftValue).compareTo((Float) rightValue);
+
+      case DOUBLE:
+        return ((Double) leftValue).compareTo((Double) rightValue);
+
+      case YEAR:
+        return ((Year) leftValue).compareTo((Year) rightValue);
+
+      case TIME:
+        return ((LocalTime) leftValue).compareTo((LocalTime) rightValue);
+
+      case DATETIME:
+        return ((LocalDateTime) leftValue).compareTo((LocalDateTime) rightValue);
+
+      case DATE:
+        return ((LocalDate) leftValue).compareTo((LocalDate) rightValue);
+
+      case TEXT:
+        return ((String) leftValue).compareTo((String) rightValue);
+
+      default:
+        throw new NotImplementedException(
+            format("edu.utdallas.davisbase.executor.Executor#evaluateComparison(DataType, Object, Object) for DataType %s",
+                dataType));
+    }
+  }
+
+  private boolean evaluateWhereEqual(DataType dataType, @Nullable Object leftValue, @Nullable Object rightValue) {
+    assert dataType != null : "dataType should not be null";
+
+    if (leftValue == null || rightValue == null) {
+      return false;
+    }
+
+    return Objects.equals(leftValue, rightValue);
+  }
+
+  private boolean evaluateWhereNotEqual(DataType dataType, @Nullable Object leftValue, @Nullable Object rightValue) {
+    assert dataType != null : "dataType should not be null";
+
+    if (leftValue == null || rightValue == null) {
+      return false;
+    }
+
+    return ! Objects.equals(leftValue, rightValue);
+  }
+
+  private boolean evaluateWhereGreaterThan(DataType dataType, @Nullable Object leftValue, @Nullable Object rightValue) {
+    assert dataType != null : "dataType should not be null";
+
+    if (leftValue == null || rightValue == null) {
+      return false;
+    }
+
+    return evaluateComparison(dataType, leftValue, rightValue) > 0;
+  }
+
+  private boolean evaluateWhereGreaterThanOrEqual(DataType dataType, @Nullable Object leftValue, @Nullable Object rightValue) {
+    assert dataType != null : "dataType should not be null";
+
+    if (leftValue == null || rightValue == null) {
+      return false;
+    }
+
+    return evaluateComparison(dataType, leftValue, rightValue) >= 0;
+  }
+
+  private boolean evaluateWhereLessThan(DataType dataType, @Nullable Object leftValue, @Nullable Object rightValue) {
+    assert dataType != null : "dataType should not be null";
+
+    if (leftValue == null || rightValue == null) {
+      return false;
+    }
+
+    return evaluateComparison(dataType, leftValue, rightValue) < 0;
+  }
+
+  private boolean evaluateWhereLessThanOrEqual(DataType dataType, @Nullable Object leftValue, @Nullable Object rightValue) {
+    assert dataType != null : "dataType should not be null";
+
+    if (leftValue == null || rightValue == null) {
+      return false;
+    }
+
+    return evaluateComparison(dataType, leftValue, rightValue) <= 0;
   }
 
 }

--- a/src/main/java/edu/utdallas/davisbase/executor/Executor.java
+++ b/src/main/java/edu/utdallas/davisbase/executor/Executor.java
@@ -183,6 +183,7 @@ public class Executor {
     return result;
   }
 
+  // TODO Implement support for WHERE clause in Executor#executeDelete(DeleteCommand)
   protected DeleteResult executeDelete(DeleteCommand command) throws ExecuteException, StorageException {
     assert command != null : "command should not be null";
     assert context != null : "context should not be null";
@@ -262,6 +263,7 @@ public class Executor {
     return result;
   }
 
+  // TODO Implement support for WHERE clause in Executor#executeSelect(SelectCommand)
   protected SelectResult executeSelectCommand(SelectCommand command) throws ExecuteException, StorageException, IOException {
     assert command != null : "command should not be null";
     assert context != null : "context should not be null";
@@ -376,6 +378,7 @@ public class Executor {
     return result;
   }
 
+  // TODO Implement support for WHERE clause in Executor#executeUpdate(UpdateCommand)
   protected UpdateResult executeUpdate(UpdateCommand command) throws ExecuteException, StorageException {
     assert command != null : "command should not be null";
     assert context != null : "context should not be null";

--- a/src/main/java/edu/utdallas/davisbase/parser/Parser.java
+++ b/src/main/java/edu/utdallas/davisbase/parser/Parser.java
@@ -15,6 +15,7 @@ import net.sf.jsqlparser.statement.drop.Drop;
 import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.select.*;
 import net.sf.jsqlparser.statement.update.Update;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -112,7 +113,6 @@ public class Parser {
               }
             }
           }
-
         } else {
           throw new ParseException("DavisBase only supports simple select statements");
         }
@@ -120,7 +120,8 @@ public class Parser {
           selectStatement.toString(),
           pSelect.getFromItem().toString(),
           pSelect.getSelectItems(),
-          (pSelect.getSelectItems().get(0) instanceof AllColumns)
+          (pSelect.getSelectItems().get(0) instanceof AllColumns),
+          parseWhereExpression(pSelect.getWhere())
         );
         return select;
       } else {
@@ -135,7 +136,11 @@ public class Parser {
    * @param where clause to parse
    * @return WhereExpression representation of the expression
    */
-  public WhereExpression parseWhereExpression(Expression where) throws ParseWhereException {
+  public @Nullable WhereExpression parseWhereExpression(@Nullable Expression where) throws ParseWhereException {
+    if(null==where){
+      return null;
+    }
+
     WhereExpression whereExpression;
     if (where instanceof EqualsTo) {
       EqualsTo equals = (EqualsTo) where;

--- a/src/main/java/edu/utdallas/davisbase/representation/DeleteCommandRepresentation.java
+++ b/src/main/java/edu/utdallas/davisbase/representation/DeleteCommandRepresentation.java
@@ -1,12 +1,14 @@
 package edu.utdallas.davisbase.representation;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public class DeleteCommandRepresentation implements CommandRepresentation {
 
   private final String command;
   private final String table;
-  private final WhereExpression whereClause;
+  private final @Nullable WhereExpression whereClause;
 
-  public DeleteCommandRepresentation(String command, String table, WhereExpression whereClause) {
+  public DeleteCommandRepresentation(String command, String table, @Nullable WhereExpression whereClause) {
     this.command = command;
     this.table = table;
     this.whereClause = whereClause;
@@ -16,7 +18,7 @@ public class DeleteCommandRepresentation implements CommandRepresentation {
     return table;
   }
 
-  public WhereExpression getWhereClause() {
+  public @Nullable WhereExpression getWhereClause() {
     return whereClause;
   }
 

--- a/src/main/java/edu/utdallas/davisbase/representation/SelectCommandRepresentation.java
+++ b/src/main/java/edu/utdallas/davisbase/representation/SelectCommandRepresentation.java
@@ -1,6 +1,8 @@
 package edu.utdallas.davisbase.representation;
 
+import jdk.nashorn.internal.objects.annotations.Where;
 import net.sf.jsqlparser.statement.select.SelectItem;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -12,13 +14,14 @@ public class SelectCommandRepresentation implements CommandRepresentation {
   private final List<SelectItem> columns;
   private final String table;
   private final boolean all;
-  //professor indicated where expression would not be tested for part 1
+  private final @Nullable WhereExpression whereClause;
 
-  public SelectCommandRepresentation(String command, String table, List<SelectItem> columns, boolean all){
+  public SelectCommandRepresentation(String command, String table, List<SelectItem> columns, boolean all, @Nullable WhereExpression whereClause){
     this.command=command;
     this.columns = Collections.unmodifiableList(new ArrayList<>(columns));
     this.table=table;
     this.all=all;
+    this.whereClause = whereClause;
   }
 
   public List<SelectItem> getColumns() {
@@ -31,6 +34,10 @@ public class SelectCommandRepresentation implements CommandRepresentation {
 
   public boolean isAll() {
     return all;
+  }
+
+  public @Nullable WhereExpression getWhereClause() {
+    return whereClause;
   }
 
   @Override
@@ -50,6 +57,7 @@ public class SelectCommandRepresentation implements CommandRepresentation {
       ", columns=" + columns +
       ", table='" + table + '\'' +
       ", all=" + all +
+      ", whereClause=" + whereClause +
       '}';
   }
 }

--- a/src/main/java/edu/utdallas/davisbase/representation/UpdateCommandRepresentation.java
+++ b/src/main/java/edu/utdallas/davisbase/representation/UpdateCommandRepresentation.java
@@ -2,6 +2,7 @@ package edu.utdallas.davisbase.representation;
 
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.schema.Column;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,9 +14,9 @@ public class UpdateCommandRepresentation implements CommandRepresentation {
   private final String table;
   private final List<Column> columns;
   private final List<Expression> values;
-  private final WhereExpression whereClause;
+  private final @Nullable WhereExpression whereClause;
 
-  public UpdateCommandRepresentation(String command, String table, List<Column> columns, List<Expression> values, WhereExpression whereClause) {
+  public UpdateCommandRepresentation(String command, String table, List<Column> columns, List<Expression> values, @Nullable WhereExpression whereClause) {
     this.command = command;
     this.table = table;
     this.columns = Collections.unmodifiableList(new ArrayList<>(columns));
@@ -35,7 +36,7 @@ public class UpdateCommandRepresentation implements CommandRepresentation {
     return values;
   }
 
-  public WhereExpression getWhereClause() {
+  public @Nullable WhereExpression getWhereClause() {
     return whereClause;
   }
 

--- a/src/main/java/edu/utdallas/davisbase/representation/WhereExpression.java
+++ b/src/main/java/edu/utdallas/davisbase/representation/WhereExpression.java
@@ -1,6 +1,6 @@
 package edu.utdallas.davisbase.representation;
 
-import net.sf.jsqlparser.expression.*;
+import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.schema.Column;
 
 public class WhereExpression {


### PR DESCRIPTION
Core compilation and execution logic for the `WHERE` clause. Also includes the implementation of the `WHERE` clause filtering in `Executor#execute(SelectCommand)`. _(does not include it for `execute(DeleteCommand)` or `execute(UpdateCommand)` since the basic implementation of those two still has to be done first)_