### PR TITLE
`TableFile` methods for `rowId`

### DIFF
--- a/src/main/java/edu/utdallas/davisbase/storage/TableFile.java
+++ b/src/main/java/edu/utdallas/davisbase/storage/TableFile.java
@@ -1,5 +1,14 @@
 package edu.utdallas.davisbase.storage;
 
+import static java.lang.String.format;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import static edu.utdallas.davisbase.storage.TablePageType.INTERIOR;
+import static edu.utdallas.davisbase.storage.TablePageType.LEAF;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -8,15 +17,10 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Year;
 import java.time.ZoneOffset;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
+
 import edu.utdallas.davisbase.NotImplementedException;
-import edu.utdallas.davisbase.common.DavisBaseConstant;
-import static java.lang.String.format;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-import static edu.utdallas.davisbase.storage.TablePageType.INTERIOR;
-import static edu.utdallas.davisbase.storage.TablePageType.LEAF;
 
 /**
  * A DavisBase "Table" file.
@@ -185,11 +189,11 @@ public class TableFile implements Closeable {
     // }
 
     if (pageType == 0x05) {
-      rowId = getnextRowIdInterior(file);
+      rowId = getNextRowIdInterior();
       file.seek(0x09);
       file.writeInt(rowId);
     } else if (pageType == 0x0D) {
-      rowId = getnextRowId(file);
+      rowId = getNextRowId();
       file.seek(0x01);
       file.writeInt(rowId);
     }
@@ -218,18 +222,6 @@ public class TableFile implements Closeable {
     // Update table meta data with rowId
     // file.seek(0x01);
     // file.writeInt(rowId);
-
-  }
-
-  public static int getnextRowIdInterior(RandomAccessFile file) {
-    try {
-      file.seek(0x09);
-      int rowId = file.readInt();
-      return (rowId + 1);
-
-    } catch (Exception e) {
-    }
-    return -1;
 
   }
 
@@ -579,17 +571,16 @@ public class TableFile implements Closeable {
     throw new NotImplementedException();
   }
 
-  public int getnextRowId(RandomAccessFile file) throws IOException {
-    // checkNotNull(pageNo);
-    try {
-      file.seek(0x01);
+  private int getNextRowId() throws IOException {
+    file.seek(0x01);
+    int rowId = file.readInt();
+    return (rowId + 1);
+  }
 
-      int rowId = file.readInt();
-      return (rowId + 1);
-
-    } catch (Exception e) {
-    }
-    return -1;
+  private int getNextRowIdInterior() throws IOException {
+    file.seek(0x09);
+    int rowId = file.readInt();
+    return (rowId + 1);
   }
 
   private boolean hasCurrentLeafPageNo() {

--- a/src/main/java/edu/utdallas/davisbase/storage/TableFile.java
+++ b/src/main/java/edu/utdallas/davisbase/storage/TableFile.java
@@ -571,6 +571,12 @@ public class TableFile implements Closeable {
     throw new NotImplementedException();
   }
 
+  public int getCurrentMaxRowId() throws IOException {
+    file.seek(0x01);
+    final int currentMaxRowId = file.readInt();
+    return currentMaxRowId;
+  }
+
   private int getNextRowId() throws IOException {
     file.seek(0x01);
     int rowId = file.readInt();


### PR DESCRIPTION
A few refactorings and one addition.

Refactorings:

- Rename methods `getnextRowId` and `getnextInteriorRowId` to `getNextRowId` and `getNextInteriorRowId`, respectively.
- Privatize `getNextRowId` and `getNextInteriorRowId`.
- Instancize `getNextRowId` and `getNextInteriorRowId`.
- Don't supress exceptions in `getNextRowId` and `getNextInteriorRowId`.

Addition:

- Add public helper method `TableFile#getCurrentMaxRowId(): int`. (intended for use in `Executor#executeUpdate(UpdateCommand)`)

TODO:

- Extract the location of the current maximum leaf page row id to a constant. (instead of a "magic number") _(if we need to do anything else regarding this value, then we should refactor it first... otherwise, leave it as is, just don't make any new "magic numbers")